### PR TITLE
Update dependencies and versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,35 +75,21 @@ dependencies {
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    // Gives us access to coroutines, and some sugar to use it
+    // https://github.com/Kotlin/kotlinx.coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 
-    /**
-     * Upgrading causes kotlin dependency issues, as new lifecycle version
-     * already uses kotlin 1.8. Just waiting until other dependencies updated
-     * to that kotlin version will solve the issues from alone.
-     *
-     * Other option would be to exclude that specifically. Which seems
-     * more likely to stay in code base forever.
-     *
-     * Check "androidx.fragment:fragment-ktx:1.5.4" too when upgrading this dependencies.
-     */
-    //noinspection GradleDependency
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
-    //noinspection GradleDependency
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1"
-    //noinspection GradleDependency
-    implementation "androidx.lifecycle:lifecycle-common:2.5.1"
+    // https://developer.android.com/jetpack/androidx/releases/lifecycle
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.6.1"
+    implementation "androidx.lifecycle:lifecycle-common:2.6.1"
 
-    // Android changes between versions, with the AndroidX libraries we know which apis
-    // we can safely use. Also that allows us to use apis like ActivityResultContracts (helpful
-    // for Permissions) and other stuff.
+    // https://developer.android.com/jetpack/androidx/releases/activity
     implementation "androidx.activity:activity-ktx:1.7.0"
-    //noinspection GradleDependency
-    implementation "androidx.fragment:fragment-ktx:1.5.4"
+    // https://developer.android.com/jetpack/androidx/releases/fragment
+    implementation "androidx.fragment:fragment-ktx:1.5.6"
 
-    // Setup testing environment
+    // https://github.com/junit-team/junit5
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,21 +69,45 @@ sonarqube {
 }
 
 dependencies {
+    // Just typical standard dependencies
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
+    // Gives us access to coroutines, and some sugar to use it
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 
+    /**
+     * Upgrading causes kotlin dependency issues, as new lifecycle version
+     * already uses kotlin 1.8. Just waiting until other dependencies updated
+     * to that kotlin version will solve the issues from alone.
+     *
+     * Other option would be to exclude that specifically. Which seems
+     * more likely to stay in code base forever.
+     *
+     * Check "androidx.fragment:fragment-ktx:1.5.4" too when upgrading this dependencies.
+     */
+    //noinspection GradleDependency
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
+    //noinspection GradleDependency
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1"
+    //noinspection GradleDependency
     implementation "androidx.lifecycle:lifecycle-common:2.5.1"
 
+    // Android changes between versions, with the AndroidX libraries we know which apis
+    // we can safely use. Also that allows us to use apis like ActivityResultContracts (helpful
+    // for Permissions) and other stuff.
+    implementation "androidx.activity:activity-ktx:1.7.0"
+    //noinspection GradleDependency
+    implementation "androidx.fragment:fragment-ktx:1.5.4"
+
+    // Setup testing environment
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 
+    // TODO: Think about removing, we won't write UI tests anyway. If we require Android dependencies let's think about Robolectric.
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'jacoco'
     id 'org.sonarqube' version '3.5.0.2730'
+    id 'androidx.navigation.safeargs'
 }
 
 android {
@@ -90,8 +91,13 @@ dependencies {
 
     // https://developer.android.com/jetpack/androidx/releases/activity
     implementation "androidx.activity:activity-ktx:1.7.0"
+
     // https://developer.android.com/jetpack/androidx/releases/fragment
     implementation "androidx.fragment:fragment-ktx:1.5.6"
+
+    // https://developer.android.com/guide/navigation
+    implementation "androidx.navigation:navigation-fragment-ktx:2.5.3"
+    implementation "androidx.navigation:navigation-ui-ktx:2.5.3"
 
     // https://github.com/junit-team/junit5
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,10 @@ android {
             finalizedBy jacocoTestReport
         }
     }
+
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Wizards"
-        tools:targetApi="31">
+        tools:targetApi="33">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/at/aau/edu/wizards/sample/SampleFragment.kt
+++ b/app/src/main/java/at/aau/edu/wizards/sample/SampleFragment.kt
@@ -8,6 +8,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import at.aau.edu.wizards.R
+import at.aau.edu.wizards.databinding.FragmentSampleBinding
 
 class SampleFragment : Fragment() {
 
@@ -19,12 +20,18 @@ class SampleFragment : Fragment() {
         )[SampleViewModel::class.java]
     }
 
+    private var binding: FragmentSampleBinding? = null
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.fragment_sample, container, false)
+    ): View {
+        val binding = FragmentSampleBinding.inflate(inflater, container, false)
+
+        this.binding = binding
+
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -33,15 +40,22 @@ class SampleFragment : Fragment() {
         setupUI()
     }
 
+    override fun onDestroyView() {
+        binding = null // important to set binding to null here. It's a memory leak otherwise.
+        super.onDestroyView()
+    }
+
     private fun setupUI() {
-        val textView = view?.findViewById<TextView>(R.id.some_text_view)
+        val binding = this.binding ?: return
 
         viewModel.dataToBeObservedInFragment.observe(viewLifecycleOwner) { newData ->
             println("Received new data from view model. Do something with it.")
             println(newData)
 
             // could use
-            // textView?.text = "something" to update the text of the textview
+            // binding.someTextView.text = "something" to update the text of the textview
         }
+
+        // binding.someTextView.text = "something" to update the text of the textview
     }
 }

--- a/app/src/main/res/layout/fragment_sample.xml
+++ b/app/src/main/res/layout/fragment_sample.xml
@@ -2,7 +2,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/default_margin">
 
     <TextView
         android:id="@+id/some_text_view"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- 48x48dp is defined by material design to be the minimum required touch size for good UX-->
+    <dimen name="min_touch_target">48dp</dimen>
+    <!-- Default margin we keep to borders of the screen itself-->
+    <dimen name="default_margin">16dp</dimen>
+    <!-- Half margin of default_margin. Can be helpful if we items next to each other. Eg: RecyclerView. -->
+    <dimen name="default_margin_half">8dp</dimen>
+
+    <!-- Define useful dimension here-->
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,8 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    dependencies {
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3"
+    }
+}
 plugins {
     id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.3.0' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.0' apply false
+    id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.3.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 21 10:57:42 CET 2023
+#Wed Mar 29 21:51:03 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updated several dependencies of the project, resolving couple warnings we have inside Sonar.
Also we use now `ViewBinding` instead of the outdated `findViewById` approach, `SampleFragment` is updated accordingly.
Prepared for usage of `navigation component`, we will use that in future instead of manually handling `FragmentTransaction`.

@martinfri144 I saw that you used `ViewBinding` in one of your branches already. It's now the common way, so let's go for it.