### PR TITLE
feature/not_enough_players

### DIFF
--- a/app/src/main/java/at/aau/edu/wizards/ui/lobby/LobbyFragment.kt
+++ b/app/src/main/java/at/aau/edu/wizards/ui/lobby/LobbyFragment.kt
@@ -13,6 +13,7 @@ import at.aau.edu.wizards.api.Server
 import at.aau.edu.wizards.databinding.FragmentLobbyBinding
 import at.aau.edu.wizards.ui.lobby.recycler.LobbyAdapter
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.snackbar.Snackbar
 
 class LobbyFragment : Fragment() {
 
@@ -78,10 +79,16 @@ class LobbyFragment : Fragment() {
         }
 
         binding.startGameButton.setOnClickListener {
-            val amountCpu = viewModel.startGame()
-            val mainActivity = activity as? MainActivity ?: return@setOnClickListener
 
-            mainActivity.showGame(asClient = false, amountCpu = amountCpu)
+            if (viewModel.numPlayer < 3) {
+                Snackbar.make(binding.root, "Not enough players connected (minimum 3 required). Add some CPU players or wait for someone to connect!", Snackbar.LENGTH_LONG).show()
+            }
+            else {
+                val amountCpu = viewModel.startGame()
+                val mainActivity = activity as? MainActivity ?: return@setOnClickListener
+
+                mainActivity.showGame(asClient = false, amountCpu = amountCpu)
+            }
         }
     }
 }

--- a/app/src/main/java/at/aau/edu/wizards/ui/lobby/LobbyFragment.kt
+++ b/app/src/main/java/at/aau/edu/wizards/ui/lobby/LobbyFragment.kt
@@ -13,7 +13,6 @@ import at.aau.edu.wizards.api.Server
 import at.aau.edu.wizards.databinding.FragmentLobbyBinding
 import at.aau.edu.wizards.ui.lobby.recycler.LobbyAdapter
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import com.google.android.material.snackbar.Snackbar
 
 class LobbyFragment : Fragment() {
 

--- a/app/src/main/java/at/aau/edu/wizards/ui/lobby/LobbyFragment.kt
+++ b/app/src/main/java/at/aau/edu/wizards/ui/lobby/LobbyFragment.kt
@@ -81,7 +81,10 @@ class LobbyFragment : Fragment() {
         binding.startGameButton.setOnClickListener {
 
             if (viewModel.numPlayer < 3) {
-                Snackbar.make(binding.root, "Not enough players connected (minimum 3 required). Add some CPU players or wait for someone to connect!", Snackbar.LENGTH_LONG).show()
+                activity?.let {
+                    MaterialAlertDialogBuilder(it).setMessage(getString(R.string.min_player))
+                        .setPositiveButton(getString(R.string.okay), null)
+                }?.create()?.show()
             }
             else {
                 val amountCpu = viewModel.startGame()

--- a/app/src/main/java/at/aau/edu/wizards/ui/lobby/LobbyItemFactory.kt
+++ b/app/src/main/java/at/aau/edu/wizards/ui/lobby/LobbyItemFactory.kt
@@ -40,7 +40,7 @@ class LobbyItemFactory {
         result.add(LobbyItem.Header(" "))
         result.add(LobbyItem.Header("CPU Players"))
         for (i in 1..cpuPlayers) {
-            result.add(LobbyItem.CpuPlayer("CPU $i"))
+            result.add(LobbyItem.CpuPlayer("CPU Player $i"))
         }
         result.add(LobbyItem.AddCpu)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,5 +14,6 @@
     <string name="score">Score:</string>
     <string name="startnewgame">Close</string>
     <string name="max_player">There can only be a maximum of 6 players</string>
+    <string name="min_player">There are not enough players to start the game (minimum 3 required). \n\nAdd some CPU players or wait for someone to connect!</string>
     <string name="okay">Okay</string>
 </resources>


### PR DESCRIPTION
Check if there is enough players connected to start a game. The minimum number of players is 3. If there are not enough players, MaterialAlertDialogBuilder will display a message to add a CPU player to start. 